### PR TITLE
fix monster-ui apps directory typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ How to register Monster-UI apps.
 3. You need to 'register' these apps
 
 ```sh
-docker cp monster-ui.kazoo:/usr/share/nginx/html/apps apps
+docker cp monster-ui.kazoo:/usr/share/nginx/html/src/apps apps
 docker cp apps kazoo.kazoo:/home/user
 rm -rf apps
 cd kazoo


### PR DESCRIPTION
There doesn't seem to be a directory at `/usr/share/nginx/html/apps`.

But there is one at `/usr/share/nginx/html/src/apps`.

Maybe this was a typo? I have corrected it in the pull request and can verify that the command does work properly after changing it to `/usr/share/nginx/html/src/apps`