### PR TITLE
More robust configuration search and replace

### DIFF
--- a/kamailio/build/config-local.sh
+++ b/kamailio/build/config-local.sh
@@ -2,12 +2,13 @@
 ROOT=/usr/local/kamailio/etc/kamailio
 
 MY_IP=$(hostname -i)
+MY_HOSTNAME=$(hostname)
 
 # ip address
 /bin/sed -i "s/MY_IP_ADDRESS!.*!/MY_IP_ADDRESS!$MY_IP!/g" $ROOT/local.cfg
 
-# domain
-/bin/sed -i "s/kamailio.2600hz.com/$HOSTNAME/g" $ROOT/local.cfg
+# hostname
+/bin/sed -i "s/MY_HOSTNAME!.*!/MY_HOSTNAME!$MY_HOSTNAME!/g" $ROOT/local.cfg
 
 # rabbitmq
 /bin/sed -i "s/MY_AMQP_URL!.*!/MY_AMQP_URL!kazoo:\/\/guest:guest@$RABBITMQ:5672!/g" $ROOT/local.cfg

--- a/kamailio4.0/build/config-local.sh
+++ b/kamailio4.0/build/config-local.sh
@@ -3,12 +3,13 @@ cp /etc/kamailio/local.cfg.orig /etc/kamailio/local.cfg
 LOCAL=/etc/kamailio/local.cfg
 
 MY_IP=$(hostname -i)
+MY_HOSTNAME=$(hostname)
 
 # ip address
 /bin/sed -i "s/MY_IP_ADDRESS!127.0.0.1/MY_IP_ADDRESS!$MY_IP/g" $LOCAL
 
-# domain
-/bin/sed -i "s/kamailio.2600hz.com/$HOSTNAME/g" $LOCAL
+# hostname
+/bin/sed -i "s/MY_HOSTNAME!.*!/MY_HOSTNAME!$MY_HOSTNAME!/g" $LOCAL
 
 # rabbitmq
 /bin/sed -i "s/MY_AMQP_URL!kazoo:\/\/guest:guest@127.0.0.1:5672/MY_AMQP_URL!kazoo:\/\/guest:guest@$RABBITMQ:5672/g" $LOCAL


### PR DESCRIPTION
## Why does it matter?

The dockerhub images are created by extracting files from a locally running docker instance. On the local instance, config-local.sh has already executed and replaced _kamailio.2600hz.com_ with _kamailio.kazoo_. 

When config-local.sh then runs on the image uploaded to dockerhub, no replacement takes place as it is looking for _kamailio.2600hz.com_ and the file contains _kamailio.kazoo_.

**Note**: This changes the configuration to rely on `$(hostname)` instead of `$HOSTNAME`, which seems more consistent with how the other images are configured.